### PR TITLE
fix: remove redundant "42cursus-" prefix

### DIFF
--- a/features/projects.js
+++ b/features/projects.js
@@ -80,7 +80,7 @@ function addProjectExtras() {
 	if (window.location.pathname.indexOf("/projects/") > -1) {
 		projectNameIndex = 2;
 	}
-	const projectName = window.location.pathname.split("/")[projectNameIndex].replaceAll(' ', '-');
+	const projectName = window.location.pathname.split("/")[projectNameIndex].replaceAll(' ', '-').replace("42cursus-", "");
 	extrasList.appendChild(createExtraItem("icon-user-search-1", "https://find-peers.joppekoers.nl/#" + projectName, "Find peers", "Find peers that are working on this project at your campus"));
 
 	// add MLX42 link on project pages that use the MiniLibX library


### PR DESCRIPTION
On for example the "scop" project Intra prefixes names it "42cursus-scop"