### PR TITLE
Re-added external clustermaps for Paris campus

### DIFF
--- a/features/externalclustermap.js
+++ b/features/externalclustermap.js
@@ -19,6 +19,10 @@ function openClusterMap(event) {
 			url = "https://codamhero.dev/v2/clusters.php";
 			highlightAfter = true;
 			break;
+		case "Paris":
+			const headerLoginName = document.querySelector("span.login[data-login]")?.textContent;
+			url = "https://stud42.fr/clusters/" + headerLoginName;
+			break;
 		case "Kuala Lumpur":
 			url = "https://locatepeer.vercel.app/"+location;
 			break;

--- a/features/externalclustermap.js
+++ b/features/externalclustermap.js
@@ -20,7 +20,7 @@ function openClusterMap(event) {
 			highlightAfter = true;
 			break;
 		case "Paris":
-			const headerLoginName = document.querySelector("span.login[data-login]")?.textContent;
+			const headerLoginName = getProfileUserName();
 			url = "https://stud42.fr/clusters/" + headerLoginName;
 			break;
 		case "Kuala Lumpur":


### PR DESCRIPTION
[Release v3.5.0](https://github.com/FreekBes/improved_intra/releases/tag/v3.5.0) mentions:
"Previously, the Paris and Lyon campuses also linked to external clustermaps. However, as those clustermaps lacked the feature to highlight locations, I have chosen to no longer link them, favoring this new feature instead."

I found out it is in fact possible to highlight a location on 42stud.fr (the Paris campus clustermaps) by linking to the url 42stud.fr/clusters/{LOGIN}.

