### PR TITLE
Fix BH date hidden for 42cursus

### DIFF
--- a/fixes/improv.css
+++ b/fixes/improv.css
@@ -634,11 +634,6 @@ a h5:not(.profile-name) {
 	color: inherit !important;
 }
 
-/* hide double black hole date */
-#blackhole-date:last-of-type {
-	display: none !important;
-}
-
 /* remove eval sheet background */
 .scale-question-answers,
 .scale-div {


### PR DESCRIPTION
Blackhole date disappeared since an intranet update.

Before :
![image](https://user-images.githubusercontent.com/11367863/196678479-21b6404c-692a-46b4-be85-c8ad057065ee.png)

After :
![image](https://user-images.githubusercontent.com/11367863/196678536-5542a4c3-1829-4bf2-b52c-193f44430f32.png)

Following a little refactoring in the code of the profile page, this CSS condition is no longer necessary.