### PR TITLE
Add sorting by project completion date

### DIFF
--- a/fixes/general.js
+++ b/fixes/general.js
@@ -210,13 +210,24 @@ function setInternshipAdministrationImprovements(match) {
  * @param {RegExpExecArray} match
  */
 function setPageUserImprovements(match) {
-	// Sort marks listed by project name
+	// Sort marks listed by project name or by completion date
 	const projectItemsContainer = document.querySelector("#marks .overflowable-item");
 	if (projectItemsContainer) {
 		const projectItems = projectItemsContainer.querySelectorAll(".main-project-item, .collapsable");
 		const projectItemsArray = Array.from(projectItems);
-		projectItemsArray.sort((a, b) => {
-			return a.querySelector(".marked-title > a").textContent.localeCompare(b.querySelector(".marked-title > a").textContent);
+		improvedStorage.get("sort-projects-date").then(function(data) {
+			// Sort by completion date if the option is set
+			if (optionIsActive(data, "sort-projects-date")) {
+				projectItemsArray.sort((a, b) => {
+					return (Date.parse(b.querySelector(".project-item-lighteable").dataset.longDate) - Date.parse(a.querySelector(".project-item-lighteable").dataset.longDate));
+				});
+			}
+			// Default to alphabetic sorting otherwise
+			else {
+				projectItemsArray.sort((a, b) => {
+					return a.querySelector(".marked-title > a").textContent.localeCompare(b.querySelector(".marked-title > a").textContent);
+				});
+			}
 		});
 		projectItemsArray.forEach(item => {
 			projectItemsContainer.appendChild(item);


### PR DESCRIPTION
This implements a new setting, `sort-projects-date`, which can be toggled on to change the default sorting of grades on profiles from alphabetic ascending to completion date descending, putting the most recently completed projects at the top. Obviously this setting will need to be implemented on the backend before merging, because right now the whole `improvedStorage.get` block on a nonexistent setting is never entered and so no sorting is done at all.