### PR TITLE
[RFC] Add a link to MacroLibX

### DIFF
--- a/features/projects.js
+++ b/features/projects.js
@@ -90,10 +90,11 @@ function addProjectExtras() {
 	const projectName = window.location.pathname.split("/")[projectNameIndex].replaceAll(' ', '-').replace("42cursus-", "");
 	extrasList.appendChild(createExtraItem("icon-user-search-1", "https://find-peers.codam.nl/#" + projectName, "Find peers", "Find peers that are working on this project at your campus"));
 
-	// add MLX42 link on project pages that use the MiniLibX library
+	// add alternatives MiniLibX links on project pages that use the MiniLibX library
 	for (let i = 0; i < mlxProjects.length; i++) {
 		if (window.location.pathname.indexOf(mlxProjects[i]) == 0) {
 			extrasList.appendChild(createExtraItem("icon-folder-code", "https://github.com/codam-coding-college/MLX42", "MLX42 (2022, ask campus staff before using)", "Open-source OpenGL version of MLX by W2Wizard (lde-la-h)"));
+			extrasList.appendChild(createExtraItem("icon-folder-code", "https://github.com/420verfl0w/MacroLibX", "MacroLibX (2023, ask campus staff before using)", "Rewritten version of the MiniLibX using SDL2 & Vulkan"));
 			break;
 		}
 	}


### PR DESCRIPTION
Repo link: https://github.com/seekrs/MacroLibX/

MacroLibX is yet another MLX rewrite by [42Angoulême](https://42angouleme.fr) students, using SDL and Vulkan.

Its main difference with https://github.com/codam-coding-college/MLX42/ is that it aims in keeping the same API and tries to be a drop-in replacement, with only greater performance in added benefits.

It's still in its early stages, so I'm starting this issue as a draft and as a Request For Comments on both:
- if it should be included in the extension, as I think diversity in MLX implementations would benefit people the most
- if not, what would be the improvements necessary for its inclusion (if any)?