### PR TITLE
Fixed logtime fill color bug

### DIFF
--- a/features/logtimes.js
+++ b/features/logtimes.js
@@ -10,13 +10,17 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+// calculates the background color based on the theme color and nb of hours
 function addBackgroundToDays(ltDays) {
   for (let i = 0; i < ltDays.length; i++) {
     let originalTitle = ltDays[i].getAttribute("data-original-title");
     if (!originalTitle.includes("0h00")) {
       let rect = ltDays[i].getElementsByTagName("rect")[0];
-      let alpha = Math.floor((parseFloat(originalTitle.charAt(0)) / 24) * 255)
-        .toString(16);
+      let alpha = Math.floor((parseFloat(originalTitle.split("h")[0]) / 24) * 255);
+      if (alpha > 200) {
+        alpha = 200;
+      }
+      alpha = alpha.toString(16);
       if (alpha.length < 2) {
         alpha = "0" + alpha;
       }

--- a/features/logtimes.js
+++ b/features/logtimes.js
@@ -10,6 +10,23 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+function addBackgroundToDays(ltDays) {
+  for (let i = 0; i < ltDays.length; i++) {
+    let originalTitle = ltDays[i].getAttribute("data-original-title");
+    if (!originalTitle.includes("0h00")) {
+      let rect = ltDays[i].getElementsByTagName("rect")[0];
+      let alpha = Math.floor((parseFloat(originalTitle.charAt(0)) / 24) * 255)
+        .toString(16);
+      if (alpha.length < 2) {
+        alpha = "0" + alpha;
+      }
+      rect.setAttribute("fill",
+        getComputedStyle(rect).getPropertyValue("--theme-color")
+        + alpha);
+    }
+  }
+}
+
 function getLogTimes(settings) {
 	return new Promise(function(resolve, reject) {
 		const httpReq = new XMLHttpRequest();
@@ -207,6 +224,9 @@ function applyLogTimeChartFixes(ltSvg, settings) {
 	if (optionIsActive(settings, "logsum-week")) {
 		cumWeekLogTime(ltDays, settings);
 	}
+
+  // fill day background
+  addBackgroundToDays(ltDays);
 }
 
 if (window.location.pathname == "/" || window.location.pathname.indexOf("/users/") == 0) {


### PR DESCRIPTION
Hi!
For some reason, the color of the text in the logtime view looked correct, but the background color was always the default one:
<img width="639" alt="before1" src="https://github.com/FreekBes/improved_intra/assets/39311030/a1256195-9b24-4b06-b479-5637158a796c">
<img width="525" alt="before2" src="https://github.com/FreekBes/improved_intra/assets/39311030/1d8afc65-06a3-44c2-91e9-77b90e4ad5fd">

This happens for anyone who uses this extension. I've asked multiple people and they experience the same issue.

So I made a JS function that overrides the background color based on the user's selected theme color and the number of hours they've spent logged in.
I made it so that it never reaches full saturation. The color tops out at around 19 to 20 hours and from there it doesn't get more intense because otherwise the date wouldn't be readable:

<img width="578" alt="after1" src="https://github.com/FreekBes/improved_intra/assets/39311030/e2a90c97-80c1-4bc2-985a-58655c39a691">
<img width="498" alt="after2" src="https://github.com/FreekBes/improved_intra/assets/39311030/cddd92f7-4b59-4285-a8d9-f7e93d256249">


I think it's a good enough approximation of how this used to work and most people won't ever spent over 19h logged in anyways.

I tried making this in CSS but I don't know how to get the number of hours in CSS and they're required for the calculation.