### PR TITLE
fix: futura font name in css

### DIFF
--- a/fixes/improv.css
+++ b/fixes/improv.css
@@ -22,7 +22,7 @@ html {
 
 /* Windows Futura font-family fix */
 .futura {
-	font-family: "Futura PT", "Futura", "futura", "Helvetica", Verdana, Arial, Sans-Serif !important;
+	font-family: "Futura PT", "Futura", "futura", "futura-pt", "Helvetica", Verdana, Arial, Sans-Serif !important;
 }
 
 /* Windows Futura font family fix (BOLD) */
@@ -31,7 +31,7 @@ html {
 .exam-modal .head h4,
 #admin-user h3,
 .app-sidebar-left .marked-title {
-	font-family: "Futura PT", "Futura", "futura", "Helvetica", Verdana, Arial, Sans-Serif !important;
+	font-family: "Futura PT", "Futura", "futura", "futura-pt", "Helvetica", Verdana, Arial, Sans-Serif !important;
 	font-weight: 700 !important;
 }
 


### PR DESCRIPTION
Intranet changed font name some time ago. It's not showing the right font in some contexts (see screenshot below).

![image](https://github.com/user-attachments/assets/802849af-3b55-4fcc-9c83-7aeb0da2c87b)
