### PR TITLE
Add 2 stars visualisation for 2 outstandings

### DIFF
--- a/features/profiles.js
+++ b/features/profiles.js
@@ -6,7 +6,7 @@
 /*   By: lilefebv <lilefebv@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/09 01:01:42 by fbes              #+#    #+#             */
-/*   Updated: 2024/12/18 13:22:56 by lilefebv         ###   ########lyon.fr   */
+/*   Updated: 2024/12/18 17:19:32 by lilefebv         ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -210,7 +210,12 @@ async function showOutstandings() {
 					const otherProjMark = otherProjItems[i].parentNode.querySelector(".pull-right.text-success"); // only if mark is considered a success
 					if (otherProjMark && json["data"][projectsUserId]["all"][i] > 0) {
 						otherProjMark.classList.remove("icon-check-1"); // should actually not be here, but for just in case try to remove it anyways
-						otherProjMark.classList.add((json["data"][projectsUserId]["all"][i] >= 3 ? "icon-star-8" : "icon-star-1"));
+						if (json["data"][projectsUserId]["best"] >= 3)
+							mainProjMark.classList.add("icon-star-8");
+						else if (json["data"][projectsUserId]["best"] >= 2)
+							mainProjMark.classList.add("icon-2stars");
+						else
+							mainProjMark.classList.add("icon-star-1");
 						otherProjMark.setAttribute("title", "Received " + json["data"][projectsUserId]["all"][i] + " outstanding" + (json["data"][projectsUserId]["all"][i] > 1 ? "s" : ""));
 					}
 				}

--- a/features/profiles.js
+++ b/features/profiles.js
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
-/*                                                        ::::::::            */
-/*   profiles.js                                        :+:    :+:            */
-/*                                                     +:+                    */
-/*   By: fbes <fbes@student.codam.nl>                 +#+                     */
-/*                                                   +#+                      */
-/*   Created: 2022/01/09 01:01:42 by fbes          #+#    #+#                 */
-/*   Updated: 2022/04/01 19:49:24 by fbes          ########   odam.nl         */
+/*                                                        :::      ::::::::   */
+/*   profiles.js                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lilefebv <lilefebv@student.42lyon.fr>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/01/09 01:01:42 by fbes              #+#    #+#             */
+/*   Updated: 2024/12/18 13:22:56 by lilefebv         ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -195,7 +195,12 @@ async function showOutstandings() {
 				const mainProjMark = mainProjItem.querySelector(".pull-right.text-success"); // only if mark is considered a success
 				if (mainProjMark && json["data"][projectsUserId]["best"] > 0) {
 					mainProjMark.classList.remove("icon-check-1");
-					mainProjMark.classList.add((json["data"][projectsUserId]["best"] >= 3 ? "icon-star-8" : "icon-star-1"));
+					if (json["data"][projectsUserId]["best"] >= 3)
+						mainProjMark.classList.add("icon-star-8");
+					else if (json["data"][projectsUserId]["best"] >= 2)
+						mainProjMark.classList.add("icon-2stars");
+					else
+						mainProjMark.classList.add("icon-star-1");
 					mainProjMark.setAttribute("title", "Received " + json["data"][projectsUserId]["best"] + " outstanding" + (json["data"][projectsUserId]["best"] > 1 ? "s" : ""));
 				}
 

--- a/features/themes/apply.css
+++ b/features/themes/apply.css
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
-/*                                                        ::::::::            */
-/*   apply.css                                          :+:    :+:            */
-/*                                                     +:+                    */
-/*   By: fbes <fbes@student.codam.nl>                 +#+                     */
-/*                                                   +#+                      */
-/*   Created: 2021/11/13 00:38:03 by fbes          #+#    #+#                 */
-/*   Updated: 2024/01/17 20:53:55 by fbes          ########   odam.nl         */
+/*                                                        :::      ::::::::   */
+/*   apply.css                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lilefebv <lilefebv@student.42lyon.fr>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/11/13 00:38:03 by fbes              #+#    #+#             */
+/*   Updated: 2024/12/18 17:07:44 by lilefebv         ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -738,6 +738,16 @@ li.scaleteam-list-item .rating:not([data-positive=""]) {
 #partnerships .partnership-item:hover,
 #accreditations .partnership-item:hover {
 	background-color: var(--list-hover-background-color) !important;
+}
+
+.icon-2stars::before {
+	content: "\e09d\e09d";
+	font-size: 11px;
+	height: 20px;
+	padding-top: 6px;
+	letter-spacing: -2px;
+	font-weight: 900 !important;
+	transform: translateX(-1px);
 }
 
 /* slots page */


### PR DESCRIPTION
It's always sad to see only one star on the profile page when we actually got 2 outstanding evaluations. This change fixes that by displaying 2 stars for 2 outstanding evaluations, while keeping 1 star for 1 outstanding and 3 stars for 3 outstanding.
![Screenshot from 2024-12-18 17-49-54](https://github.com/user-attachments/assets/4721deb0-4326-4990-a3b1-84bf3e8eec9f)

If showing only one star for 2 outstanding is intentional, feel free to reject this pull request.