### PR TITLE
[codex] Update Intra v3 compatibility

### DIFF
--- a/background/comm.js
+++ b/background/comm.js
@@ -16,15 +16,27 @@ const incognitoPorts = [];
 
 // message only ports in non-incognito context
 function messageNormalPorts(msg) {
-	for (let i = 0; i < normalPorts.length; i++) {
-		normalPorts[i].postMessage(msg);
+	for (let i = normalPorts.length - 1; i >= 0; i--) {
+		try {
+			normalPorts[i].postMessage(msg);
+		}
+		catch (err) {
+			iConsole.warn("Dropping disconnected normal port:", err);
+			normalPorts.splice(i, 1);
+		}
 	}
 }
 
 // message only ports in incognito context
 function messageIncognitoPorts(msg) {
-	for (let i = 0; i < incognitoPorts.length; i++) {
-		incognitoPorts[i].postMessage(msg);
+	for (let i = incognitoPorts.length - 1; i >= 0; i--) {
+		try {
+			incognitoPorts[i].postMessage(msg);
+		}
+		catch (err) {
+			iConsole.warn("Dropping disconnected incognito port:", err);
+			incognitoPorts.splice(i, 1);
+		}
 	}
 }
 
@@ -49,6 +61,10 @@ function isIncognitoPort(port) {
 	return (port.name == incognitoPortName);
 }
 
+function isSyncAuthError(err) {
+	return (typeof err == "string" && err.toLowerCase().indexOf("invalid ext_token") > -1);
+}
+
 // resync on port message function
 function resyncOnPortMessage(incognitoSession) {
 	const type = (incognitoSession ? "incognito" : "normal");
@@ -63,6 +79,13 @@ function resyncOnPortMessage(incognitoSession) {
 					messagePortsOfType(type, { action: "resynced" });
 				})
 				.catch(function(err) {
+					if (isSyncAuthError(err)) {
+						iConsole.warn("Improved Intra sync server is not authenticated. Keeping local settings.");
+						improvedStorage.set({ "iintra-server-session": false });
+						messagePortsOfType(type, { action: "resynced" });
+						checkForExtToken(incognitoSession, false);
+						return;
+					}
 					iConsole.error("Could not retrieve settings from server:", err);
 
 					// Check if the extension token was still valid

--- a/features/profiles.js
+++ b/features/profiles.js
@@ -307,6 +307,9 @@ function addProfileInfosItem(userInfos, itemId, itemTitle, itemIcon, itemContent
 function immediateProfileChanges() {
 	// add custom banner image container
 	if (gProfileBanner) {
+		if (window.location.hostname == "profile-v3.intra.42.fr") {
+			gProfileBanner.classList.add("improved-intra-v3-profile-banner");
+		}
 		gCustomBanner = document.createElement("div");
 		gCustomBanner.className = "improved-intra-banner";
 		gProfileBanner.insertBefore(gCustomBanner, gProfileBanner.children[0]);
@@ -346,7 +349,7 @@ function immediateProfileChanges() {
 }
 
 gUName = getProfileUserName();
-gProfileBanner = document.querySelector(".container-inner-item.profile-item-top.profile-banner");
+gProfileBanner = document.querySelector(".container-inner-item.profile-item-top.profile-banner, .content header");
 immediateProfileChanges();
 improvedStorage.get(["username", "show-custom-profiles", "outstandings"]).then(function(data) {
 	gExtSettings = data;

--- a/features/themes/apply.css
+++ b/features/themes/apply.css
@@ -31,29 +31,74 @@ body.bg-white {
 }
 
 /* tailwind text color Intra v3 */
-.text-black {
+.text-black,
+#root .text-black {
 	color: var(--text-color) !important;
 }
 
 /* tailwind body background Intra v3 */
-.bg-zinc-50 {
+.bg-zinc-50,
+#root,
+#root .App,
+#root .content,
+#root .bg-zinc-50 {
 	background-color: var(--body-background-color) !important;
 }
 
 /* tailwind backgrounds Intra v3 */
-.bg-white {
+.bg-white,
+#root .bg-white,
+#root .bg-popover,
+#root .bg-zinc-100,
+#root .bg-stone-300 {
 	background-color: var(--container-background-color) !important;
 }
 
 /* tailwind borders Intra v3 */
 .border-neutral-200,
-.border-white {
+.border-white,
+#root .border-neutral-200,
+#root .border-neutral-600,
+#root .border-white,
+#root .border-input {
 	border-color: var(--general-border-color) !important;
 }
 
 /* achievement Intra v3 */
-.bg-zinc-100 {
+.bg-zinc-100,
+#root .hover\:bg-zinc-100:hover,
+#root .focus\:bg-zinc-100:focus {
 	background-color: var(--general-border-color) !important;
+}
+
+/* Intra v3 app shell */
+#root .w-full.top-0.fixed.z-40 .bg-white,
+#root input[type="search"],
+#root [role="menu"] {
+	background-color: var(--top-navbar-background-color) !important;
+	color: var(--text-color) !important;
+}
+
+#root input[type="search"]::placeholder {
+	color: var(--secondary-text-color) !important;
+}
+
+#root .w-full.top-0.fixed.z-40 svg,
+#root .w-full.top-0.fixed.z-40 svg path,
+#root .w-full.top-0.fixed.z-40 svg line {
+	color: var(--text-color) !important;
+	stroke: var(--text-color) !important;
+}
+
+#root .justify-center.flex.flex-col.gap-4.text-sm.text-gray-500 {
+	background-color: var(--body-background-color) !important;
+	color: var(--secondary-text-color) !important;
+}
+
+#root .text-gray-500,
+#root .text-neutral-400,
+#root .text-stone-500 {
+	color: var(--secondary-text-color) !important;
 }
 
 a:not([style*="color:"]):not(.btn),

--- a/features/themes/apply.css
+++ b/features/themes/apply.css
@@ -30,9 +30,30 @@ body.bg-white {
 	color: var(--text-color) !important;
 }
 
-/* somewhat of a fix for Intra v3: don't apply text colors, since the background does not change */
-body #root .App {
-	color: rgb(0 0 0 / var(--tw-text-opacity)) !important;
+/* tailwind text color Intra v3 */
+.text-black {
+	color: var(--text-color) !important;
+}
+
+/* tailwind body background Intra v3 */
+.bg-zinc-50 {
+	background-color: var(--body-background-color) !important;
+}
+
+/* tailwind backgrounds Intra v3 */
+.bg-white {
+	background-color: var(--container-background-color) !important;
+}
+
+/* tailwind borders Intra v3 */
+.border-neutral-200,
+.border-white {
+	border-color: var(--general-border-color) !important;
+}
+
+/* achievement Intra v3 */
+.bg-zinc-100 {
+	background-color: var(--general-border-color) !important;
 }
 
 a:not([style*="color:"]):not(.btn),

--- a/fixes/general.js
+++ b/fixes/general.js
@@ -28,8 +28,64 @@ function createMenuLink(userMenu, href, text, position) {
 	}
 }
 
+function createV3MenuLink(userMenu, href, text, position) {
+	const menuItem = document.createElement("div");
+	const existingMenuItem = userMenu.querySelector("[role='menuitem']");
+	menuItem.setAttribute("role", "menuitem");
+	menuItem.setAttribute("tabindex", "-1");
+	menuItem.className = existingMenuItem ? existingMenuItem.className : "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors";
+	menuItem.innerText = text;
+	menuItem.addEventListener("click", function() {
+		window.location.href = href;
+	});
+	menuItem.addEventListener("keyup", function(event) {
+		if (event.key == "Enter" || event.key == " ") {
+			window.location.href = href;
+		}
+	});
+	if (position && typeof position == "object") {
+		userMenu.insertBefore(menuItem, position);
+	}
+	else {
+		userMenu.appendChild(menuItem);
+	}
+}
+
+function improveV3UserMenu(userMenu) {
+	if (!userMenu || userMenu.dataset.improvedIntraMenu == "true") {
+		return;
+	}
+	userMenu.dataset.improvedIntraMenu = "true";
+	if (![...userMenu.querySelectorAll("[role='menuitem']")].some(item => item.textContent.trim() == "Improved Intra Settings")) {
+		const settingsItem = [...userMenu.querySelectorAll("[role='menuitem']")].find(item => item.textContent.trim() == "Settings");
+		createV3MenuLink(userMenu, "https://iintra.freekb.es/v2/options", "Improved Intra Settings", settingsItem);
+	}
+}
+
+function watchV3UserMenu() {
+	if (window.location.hostname != "profile-v3.intra.42.fr") {
+		return;
+	}
+	document.querySelectorAll("[data-radix-menu-content][role='menu']").forEach(improveV3UserMenu);
+	const observer = new MutationObserver(function(mutations) {
+		for (const mutation of mutations) {
+			for (const addedNode of mutation.addedNodes) {
+				if (!(addedNode instanceof HTMLElement)) {
+					continue;
+				}
+				if (addedNode.matches("[data-radix-menu-content][role='menu']")) {
+					improveV3UserMenu(addedNode);
+				}
+				addedNode.querySelectorAll?.("[data-radix-menu-content][role='menu']").forEach(improveV3UserMenu);
+			}
+		}
+	});
+	observer.observe(document.body, { childList: true, subtree: true });
+}
+
 function setGeneralImprovements() {
 	if (isIntraV3) {
+		watchV3UserMenu();
 		return;
 	}
 
@@ -41,7 +97,13 @@ function setGeneralImprovements() {
 	const userMenu = document.querySelector(".main-navbar-user-nav ul[role='menu']");
 	if (userMenu) {
 		// add link to extension options in account/user menu
-		createMenuLink(userMenu, "https://iintra.freekb.es/v2/options", "Improved Intra Settings", userMenu.lastElementChild);
+		const intraSettingsOption = userMenu.querySelector("a[href='https://profile.intra.42.fr/languages']");
+		const intraSettingsPosition = intraSettingsOption ? intraSettingsOption.closest("li")?.nextSibling : userMenu.lastElementChild || "bottom";
+
+		// extensionSettingsLink.setAttribute("href", chrome.runtime.getURL('options/options.html'));
+		if (!userMenu.querySelector("a[href='https://iintra.freekb.es/v2/options']")) {
+			createMenuLink(userMenu, "https://iintra.freekb.es/v2/options", "Improved Intra Settings", intraSettingsPosition);
+		}
 
 		// add view my profile link if it seems to be missing from the menu
 		if (!userMenu.querySelector("a[href*='https://profile.intra.42.fr/users/']")) {
@@ -53,6 +115,7 @@ function setGeneralImprovements() {
 			createMenuLink(userMenu, "https://profile.intra.42.fr/slots", "Manage slots");
 		}
 	}
+	watchV3UserMenu();
 
 	// fix href of "Have a problem?" button in header next to user menu
 	const problemButtonWrapper = document.querySelector(".main-navbar-user-nav > .help-btn-wrapper");
@@ -400,23 +463,12 @@ async function setPageEvaluationsImprovements(match) {
 	}
 }
 
-/**
- * Improvements for Intra v3 early access page (add note that v3 is not supported by Improved Intra)
- * @param {RegExpExecArray} match
- */
 function setEarlyAccessImprovements(match) {
 	const earlyAccessContainer = document.getElementById("profile-v3-early-access-container");
 	if (earlyAccessContainer) {
-		const earlyAccessNote = document.createElement("p");
-		earlyAccessNote.className = "alert alert-warning";
-		earlyAccessNote.style.marginTop = "6rem";
-		earlyAccessNote.style.fontWeight = "bold";
-		earlyAccessNote.style.whiteSpace = "pre-wrap"; // make sure the note line breaks on \r\n
-		earlyAccessNote.innerText = "Improved Intra is not compatible with Intra v3 and probably never will be.\r\n\r\nThis is because the new Intra is impossible to work with for extensions due to its heavy use of elements without specific ids or classes (blame poorly used frameworks).\r\nIf you want to use Improved Intra without issues, keep using Intra v2. If you want to use v3, it is recommended to disable the Improved Intra extension.";
-		earlyAccessContainer.appendChild(earlyAccessNote);
-
 		// replace the container class with container-inner-item class to prevent the container from going out of bounds
-		while (wrongContainerUse = earlyAccessContainer.closest(".container")) {
+		let wrongContainerUse;
+		while ((wrongContainerUse = earlyAccessContainer.closest(".container"))) {
 			iConsole.log("Replaced container class with container-inner-item class", wrongContainerUse);
 			wrongContainerUse.classList.replace("container", "container-inner-item");
 		}

--- a/fixes/improv.css
+++ b/fixes/improv.css
@@ -35,38 +35,6 @@ html {
 	font-weight: 700 !important;
 }
 
-/* warning for Intra v3 incompatibility */
-#improved-intra-v3-incompatibility-warning {
-	position: fixed;
-	bottom: 0;
-	left: 80px;
-	width: calc(100% - 80px);
-	font-family: "Futura PT", "Futura", "futura", "futura-pt", "Helvetica", Verdana, Arial, Sans-Serif;
-	background-color: #fcf8e3;
-	color: #8a6d3b;
-	text-align: center;
-	padding: 8px;
-	font-weight: bold;
-	font-size: 14px;
-	box-shadow: 0 0 4px rgba(0,0,0,.14), 0 4px 8px rgba(0,0,0,.28);
-	z-index: 9999;
-}
-#improved-intra-v3-incompatibility-warning a,
-#improved-intra-v3-incompatibility-warning-close {
-	color: #b17e27 !important;
-	cursor: pointer !important;
-}
-#improved-intra-v3-incompatibility-warning a:hover,
-#improved-intra-v3-incompatibility-warning a:focus {
-	color: #c27e08 !important;
-	text-decoration: underline !important;
-}
-#improved-intra-v3-incompatibility-warning-close:hover,
-#improved-intra-v3-incompatibility-warning-close:focus {
-	color: #c27e08 !important;
-	text-shadow: 0 0 1px #8a6d3b !important;
-}
-
 /* off-screen account dropdown menu fix for short usernames */
 .main-navbar-user-nav .dropdown .dropdown-menu {
 	left: unset !important;
@@ -533,8 +501,18 @@ a[data-tooltip-login].student-kind-student::before,
 	position: relative;
 }
 
+.improved-intra-v3-profile-banner {
+	position: relative;
+	overflow: hidden;
+}
+
 /* set z-index for all elements in the profile banner to accustom for the custom banner */
 .container-inner-item.profile-item-top.profile-banner > *:not(.improved-intra-banner) {
+	z-index: 1 !important;
+}
+
+.improved-intra-v3-profile-banner > *:not(.improved-intra-banner) {
+	position: relative;
 	z-index: 1 !important;
 }
 

--- a/fixes/v3detector.js
+++ b/fixes/v3detector.js
@@ -4,33 +4,5 @@ let isIntraV3 = false;
 const rootElem = document.getElementById("root");
 if (rootElem && rootElem.parentElement.nodeName === "BODY") {
 	isIntraV3 = true;
-	iConsole.warn("Detected Intra v3, which is not compatible with Improved Intra. Please consider switching back to Intra v2 for the best experience: https://profile.intra.42.fr/v3_early_access");
-
-	const warningElement = document.createElement("div");
-	warningElement.id = "improved-intra-v3-incompatibility-warning";
-
-	const warningTextPart1 = document.createElement("span");
-	warningTextPart1.innerText = "Improved Intra is not compatible with Intra v3 and probably never will be. We recommend ";
-	warningElement.appendChild(warningTextPart1);
-
-	const switchBackLink = document.createElement("a");
-	switchBackLink.href = "https://profile.intra.42.fr/v3_early_access";
-	switchBackLink.innerText = "switching back to Intra v2";
-	warningElement.appendChild(switchBackLink);
-
-	const warningTextPart2 = document.createElement("span");
-	warningTextPart2.innerText = " for a better experience.";
-	warningElement.appendChild(warningTextPart2);
-
-	const closeButton = document.createElement("button");
-	closeButton.id = "improved-intra-v3-incompatibility-warning-close";
-	closeButton.innerText = "✕";
-	closeButton.style.float = "right";
-	closeButton.style.padding = "0px 6px";
-	closeButton.onclick = function() {
-		warningElement.remove();
-	};
-	warningElement.appendChild(closeButton);
-
-	document.body.insertBefore(warningElement, rootElem);
+	iConsole.log("Detected Intra v3");
 }

--- a/generic/useful.js
+++ b/generic/useful.js
@@ -55,7 +55,14 @@ function getThemeColor() {
 function getCoalitionColor() {
 	let color = getThemeColor(); // fallback
 	try {
-		color = document.getElementsByClassName("coalition-span")[0].style.color;
+		const coalitionSpan = document.getElementsByClassName("coalition-span")[0];
+		const v3CoalitionFlag = document.querySelector("header a[href*='/coalitions/'] svg[fill]");
+		if (coalitionSpan && coalitionSpan.style.color) {
+			color = coalitionSpan.style.color;
+		}
+		else if (v3CoalitionFlag && v3CoalitionFlag.getAttribute("fill")) {
+			color = v3CoalitionFlag.getAttribute("fill");
+		}
 	}
 	catch (err) {
 		iConsole.warn("Could not get coalition color, using theme color instead.");
@@ -77,11 +84,22 @@ function getCampus() {
 // get the username from a profile
 function getProfileUserName() {
 	try {
-		return (document.querySelector(".login[data-login]").getAttribute("data-login"));
+		const userMatch = window.location.pathname.match(/^\/users\/([^/]+)/);
+		if (userMatch && userMatch[1] != "me") {
+			return (userMatch[1]);
+		}
+		const login = document.querySelector(".login[data-login], [data-login]");
+		if (login) {
+			return (login.getAttribute("data-login"));
+		}
+		if (userMatch) {
+			return (userMatch[1] == "me" ? null : userMatch[1]);
+		}
 	}
 	catch (err) {
 		return (null);
 	}
+	return (null);
 }
 
 // convert hex color to rgb color object
@@ -113,7 +131,7 @@ function unsetCoalitionTextColor(event) {
 
 // returns true if the current webpage has a profile banner
 function hasProfileBanner() {
-	return (window.location.pathname.indexOf("/users/") == 0 || (window.location.hostname == "profile.intra.42.fr" && window.location.pathname == "/"));
+	return (window.location.pathname.indexOf("/users/") == 0 || ((window.location.hostname == "profile.intra.42.fr" || window.location.hostname == "profile-v3.intra.42.fr") && window.location.pathname == "/"));
 }
 
 // get the URL of the current webpage without the hash and query

--- a/options/auth2.js
+++ b/options/auth2.js
@@ -12,11 +12,51 @@
 
 iConsole.log("auth2.js script running now...");
 
-let authPort = chrome.runtime.connect({ name: portName });
-authPort.onDisconnect.addListener(function() {
-	iConsole.log("Disconnected from service worker");
-});
-authPort.onMessage.addListener(function(msg) {
+let authPort = null;
+let authPortInterval = null;
+let authPortClosed = false;
+
+function connectAuthPort() {
+	if (authPortClosed) {
+		return false;
+	}
+	authPort = chrome.runtime.connect({ name: portName });
+	authPort.onDisconnect.addListener(function() {
+		iConsole.log("Disconnected from service worker");
+		authPort = null;
+	});
+	authPort.onMessage.addListener(handleAuthPortMessage);
+	return true;
+}
+
+function disconnectAuthPort() {
+	authPortClosed = true;
+	if (authPortInterval) {
+		clearInterval(authPortInterval);
+		authPortInterval = null;
+	}
+	if (authPort) {
+		authPort.disconnect();
+		authPort = null;
+	}
+}
+
+function postAuthPortMessage(msg) {
+	if (authPortClosed) {
+		return;
+	}
+	if (!authPort && !connectAuthPort()) {
+		return;
+	}
+	try {
+		authPort.postMessage(msg);
+	}
+	catch (err) {
+		iConsole.warn("Could not message service worker:", err);
+	}
+}
+
+function handleAuthPortMessage(msg) {
 	switch (msg["action"]) {
 		case "pong":
 			iConsole.log("pong");
@@ -25,11 +65,20 @@ authPort.onMessage.addListener(function(msg) {
 			iConsole.error(msg["message"]);
 			break;
 	}
-});
-setInterval(function() {
-	authPort.disconnect();
-	authPort = chrome.runtime.connect({ name: portName });
+}
+
+connectAuthPort();
+authPortInterval = setInterval(function() {
+	if (authPortClosed) {
+		return;
+	}
+	if (authPort) {
+		authPort.disconnect();
+		authPort = null;
+	}
+	connectAuthPort();
 }, 250000);
+window.addEventListener("pagehide", disconnectAuthPort);
 
 async function checkSendSessionStatus(closeAfter = false) {
 	iConsole.log("Checking if the user is authenticated...");
@@ -37,7 +86,7 @@ async function checkSendSessionStatus(closeAfter = false) {
 	iConsole.log("iintra-server-session:", serverSession);
 	if (!serverSession) {
 		iConsole.log("(New) authenticated session detected, notifying extension...");
-		authPort.postMessage({ action: "server-session-started" });
+		postAuthPortMessage({ action: "server-session-started" });
 	}
 	if (closeAfter) {
 		iConsole.log("Closing the tab...");
@@ -67,5 +116,5 @@ else if (window.location.pathname == '/v2/ping' && document.body.textContent.toL
 else if (window.location.pathname.startsWith('/v2/disconnect')) {
 	// session actually ended
 	iConsole.log("Notifying extension that the back-end session ended...");
-	authPort.postMessage({ action: "server-session-ended" });
+	postAuthPortMessage({ action: "server-session-ended" });
 }

--- a/options/sync.js
+++ b/options/sync.js
@@ -19,11 +19,51 @@ function getLoggedInUserName() {
 	}
 }
 
-let syncPort = chrome.runtime.connect({ name: portName });
-syncPort.onDisconnect.addListener(function() {
-	iConsole.log("Disconnected from service worker");
-});
-syncPort.onMessage.addListener(function(msg) {
+let syncPort = null;
+let syncPortInterval = null;
+let syncPortClosed = false;
+
+function connectSyncPort() {
+	if (syncPortClosed) {
+		return false;
+	}
+	syncPort = chrome.runtime.connect({ name: portName });
+	syncPort.onDisconnect.addListener(function() {
+		iConsole.log("Disconnected from service worker");
+		syncPort = null;
+	});
+	syncPort.onMessage.addListener(handleSyncPortMessage);
+	return true;
+}
+
+function disconnectSyncPort() {
+	syncPortClosed = true;
+	if (syncPortInterval) {
+		clearInterval(syncPortInterval);
+		syncPortInterval = null;
+	}
+	if (syncPort) {
+		syncPort.disconnect();
+		syncPort = null;
+	}
+}
+
+function postSyncPortMessage(msg) {
+	if (syncPortClosed) {
+		return;
+	}
+	if (!syncPort && !connectSyncPort()) {
+		return;
+	}
+	try {
+		syncPort.postMessage(msg);
+	}
+	catch (err) {
+		iConsole.warn("Could not message service worker:", err);
+	}
+}
+
+function handleSyncPortMessage(msg) {
 	switch (msg["action"]) {
 		case "pong":
 			iConsole.log("pong");
@@ -35,11 +75,20 @@ syncPort.onMessage.addListener(function(msg) {
 			iConsole.error(msg["message"]);
 			break;
 	}
-});
-setInterval(function() {
-	syncPort.disconnect();
-	syncPort = chrome.runtime.connect({ name: portName });
+}
+
+connectSyncPort();
+syncPortInterval = setInterval(function() {
+	if (syncPortClosed) {
+		return;
+	}
+	if (syncPort) {
+		syncPort.disconnect();
+		syncPort = null;
+	}
+	connectSyncPort();
 }, 250000);
+window.addEventListener("pagehide", disconnectSyncPort);
 
 improvedStorage.get(["last-sync", "username"]).then(function(data) {
 	const curUsername = getLoggedInUserName();
@@ -50,7 +99,7 @@ improvedStorage.get(["last-sync", "username"]).then(function(data) {
 		// a new user logged in!
 		improvedStorage.set({"username": curUsername}).then(function() {
 			iConsole.log("Intra username stored in local storage, now resyncing settings...");
-			syncPort.postMessage({ action: "resync" });
+			postSyncPortMessage({ action: "resync" });
 		});
 	}
 	else {

--- a/options/unsync.js
+++ b/options/unsync.js
@@ -16,11 +16,51 @@ improvedStorage.remove("username").then(function() {
 	iConsole.log("Signed out from Intra, so removed the username to synchronize with. Settings will be kept locally, until another person signs in.");
 });
 
-let syncPort = chrome.runtime.connect({ name: portName });
-syncPort.onDisconnect.addListener(function() {
-	iConsole.log("Disconnected from service worker");
-});
-syncPort.onMessage.addListener(function(msg) {
+let syncPort = null;
+let syncPortInterval = null;
+let syncPortClosed = false;
+
+function connectSyncPort() {
+	if (syncPortClosed) {
+		return false;
+	}
+	syncPort = chrome.runtime.connect({ name: portName });
+	syncPort.onDisconnect.addListener(function() {
+		iConsole.log("Disconnected from service worker");
+		syncPort = null;
+	});
+	syncPort.onMessage.addListener(handleSyncPortMessage);
+	return true;
+}
+
+function disconnectSyncPort() {
+	syncPortClosed = true;
+	if (syncPortInterval) {
+		clearInterval(syncPortInterval);
+		syncPortInterval = null;
+	}
+	if (syncPort) {
+		syncPort.disconnect();
+		syncPort = null;
+	}
+}
+
+function postSyncPortMessage(msg) {
+	if (syncPortClosed) {
+		return;
+	}
+	if (!syncPort && !connectSyncPort()) {
+		return;
+	}
+	try {
+		syncPort.postMessage(msg);
+	}
+	catch (err) {
+		iConsole.warn("Could not message service worker:", err);
+	}
+}
+
+function handleSyncPortMessage(msg) {
 	switch (msg["action"]) {
 		case "pong":
 			iConsole.log("pong");
@@ -29,13 +69,22 @@ syncPort.onMessage.addListener(function(msg) {
 			iConsole.error(msg["message"]);
 			break;
 	}
-});
-setInterval(function() {
-	syncPort.disconnect();
-	syncPort = chrome.runtime.connect({ name: portName });
-}, 250000);
+}
 
-syncPort.postMessage({ action: "intra-logout" });
+connectSyncPort();
+syncPortInterval = setInterval(function() {
+	if (syncPortClosed) {
+		return;
+	}
+	if (syncPort) {
+		syncPort.disconnect();
+		syncPort = null;
+	}
+	connectSyncPort();
+}, 250000);
+window.addEventListener("pagehide", disconnectSyncPort);
+
+postSyncPortMessage({ action: "intra-logout" });
 
 // const iintraLogoutWindow = window.open("https://iintra.freekb.es/v2/disconnect?continue=/v2/ping", "iintra-logout", "width=10,height=10");
 // iintraLogoutWindow.addEventListener("load", function() {

--- a/scripts/cdp-scrape-intra-v3.mjs
+++ b/scripts/cdp-scrape-intra-v3.mjs
@@ -1,0 +1,210 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const CDP_HOST = process.env.CDP_HOST || "http://127.0.0.1:9222";
+const OUT_DIR = process.env.OUT_DIR || "temp/intra-v3";
+const WAIT_MS = Number(process.env.WAIT_MS || 2500);
+const MAX_LANDMARKS = Number(process.env.MAX_LANDMARKS || 800);
+const MAX_BODY_TEXT_CHARS = Number(process.env.MAX_BODY_TEXT_CHARS || 20000);
+const INCLUDE_FULL_BODY_TEXT = process.env.INCLUDE_FULL_BODY_TEXT === "1";
+const WebSocketImpl = globalThis.WebSocket;
+
+if (!WebSocketImpl || !globalThis.fetch) {
+	throw new Error("This scraper requires Node.js 22+ with global fetch and WebSocket support.");
+}
+
+const routes = (process.argv.slice(2).length
+	? process.argv.slice(2)
+	: ["current"]);
+
+class CdpClient {
+	constructor(webSocketUrl) {
+		this.webSocketUrl = webSocketUrl;
+		this.nextId = 1;
+		this.pending = new Map();
+	}
+
+	async connect() {
+		this.ws = new WebSocketImpl(this.webSocketUrl);
+		this.ws.addEventListener("message", event => {
+			const message = JSON.parse(event.data);
+			if (!message.id || !this.pending.has(message.id)) {
+				return;
+			}
+			const { resolve, reject } = this.pending.get(message.id);
+			this.pending.delete(message.id);
+			if (message.error) {
+				reject(new Error(JSON.stringify(message.error)));
+			}
+			else {
+				resolve(message.result);
+			}
+		});
+		await new Promise((resolve, reject) => {
+			this.ws.addEventListener("open", resolve, { once: true });
+			this.ws.addEventListener("error", reject, { once: true });
+		});
+	}
+
+	send(method, params = {}) {
+		const id = this.nextId++;
+		return new Promise((resolve, reject) => {
+			this.pending.set(id, { resolve, reject });
+			this.ws.send(JSON.stringify({ id, method, params }));
+		});
+	}
+
+	async evaluate(expression) {
+		const result = await this.send("Runtime.evaluate", {
+			expression,
+			awaitPromise: true,
+			returnByValue: true
+		});
+		if (result.exceptionDetails) {
+			throw new Error(JSON.stringify(result.exceptionDetails));
+		}
+		return result.result.value;
+	}
+
+	close() {
+		this.ws.close();
+	}
+}
+
+function sleep(ms) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function safeName(value) {
+	return value
+		.replace(/^https?:\/\//, "")
+		.replace(/[^a-z0-9]+/gi, "-")
+		.replace(/^-|-$/g, "")
+		.toLowerCase()
+		.slice(0, 100) || "page";
+}
+
+async function getTargets() {
+	return fetch(`${CDP_HOST}/json/list`).then(response => response.json());
+}
+
+async function getProfileV3Target() {
+	const targets = await getTargets();
+	const target = targets.find(item => item.type === "page" && item.url.includes("profile-v3.intra.42.fr"))
+		|| targets.find(item => item.type === "page");
+	if (!target) {
+		throw new Error(`No Chrome page target found at ${CDP_HOST}`);
+	}
+	return target;
+}
+
+async function enableDomains(cdp) {
+	await cdp.send("Runtime.enable");
+	await cdp.send("Page.enable");
+	await cdp.send("DOM.enable");
+	await cdp.send("CSS.enable");
+}
+
+async function waitForSettledPage(cdp) {
+	await cdp.evaluate(`new Promise(resolve => {
+		if (document.readyState === "complete") resolve();
+		else window.addEventListener("load", resolve, { once: true });
+	})`);
+	await sleep(WAIT_MS);
+}
+
+async function scrapePage(cdp, label, index) {
+	await waitForSettledPage(cdp);
+
+	const snapshot = await cdp.evaluate(`(() => {
+			const maxLandmarks = ${JSON.stringify(MAX_LANDMARKS)};
+			const maxBodyTextChars = ${JSON.stringify(MAX_BODY_TEXT_CHARS)};
+			const includeFullBodyText = ${JSON.stringify(INCLUDE_FULL_BODY_TEXT)};
+			const trim = value => (value || "").replace(/\\s+/g, " ").trim();
+			const visibleText = element => trim(element.innerText || element.textContent || "").slice(0, 240);
+		const rectFor = element => {
+			const rect = element.getBoundingClientRect();
+			return {
+				x: Math.round(rect.x),
+				y: Math.round(rect.y),
+				width: Math.round(rect.width),
+				height: Math.round(rect.height)
+			};
+		};
+		const selectorFor = element => {
+			if (element.id) return "#" + CSS.escape(element.id);
+			const classes = [...element.classList].slice(0, 4).map(className => "." + CSS.escape(className)).join("");
+			return element.tagName.toLowerCase() + classes;
+		};
+			const landmarkElements = [...document.querySelectorAll("header, nav, main, aside, footer, section, article, [role], [aria-label], [data-testid], [data-test], [class], [id]")];
+			const bodyText = document.body.innerText || "";
+		return {
+			capturedAt: new Date().toISOString(),
+			url: location.href,
+			title: document.title,
+			viewport: { width: innerWidth, height: innerHeight, devicePixelRatio },
+			assets: {
+				scripts: [...document.scripts].map(script => script.src).filter(Boolean),
+				stylesheets: [...document.querySelectorAll("link[rel='stylesheet']")].map(link => link.href).filter(Boolean)
+			},
+			links: [...document.links].map(anchor => ({
+				text: visibleText(anchor),
+				href: anchor.href,
+				selector: selectorFor(anchor),
+				rect: rectFor(anchor)
+			})),
+			landmarkCount: landmarkElements.length,
+			landmarks: landmarkElements.slice(0, maxLandmarks).map(element => ({
+				tag: element.tagName.toLowerCase(),
+				id: element.id || "",
+				className: element.className || "",
+				role: element.getAttribute("role") || "",
+				ariaLabel: element.getAttribute("aria-label") || "",
+				dataTestid: element.getAttribute("data-testid") || "",
+				dataTest: element.getAttribute("data-test") || "",
+				selector: selectorFor(element),
+				text: visibleText(element),
+				rect: rectFor(element)
+			})).filter(item => item.rect.width || item.rect.height || item.text),
+			bodyText: includeFullBodyText ? bodyText : bodyText.slice(0, maxBodyTextChars),
+			bodyTextTruncated: !includeFullBodyText && bodyText.length > maxBodyTextChars
+		};
+	})()`);
+
+	const html = await cdp.evaluate("document.documentElement.outerHTML");
+	const screenshot = await cdp.send("Page.captureScreenshot", {
+		format: "png",
+		captureBeyondViewport: true,
+		fromSurface: true
+	});
+
+	const name = `${String(index).padStart(2, "0")}-${safeName(label === "current" ? snapshot.url : label)}`;
+	await writeFile(join(OUT_DIR, `${name}.html`), html);
+	await writeFile(join(OUT_DIR, `${name}.json`), JSON.stringify(snapshot, null, "\t"));
+	await writeFile(join(OUT_DIR, `${name}.png`), Buffer.from(screenshot.data, "base64"));
+	console.log(`${name}: ${snapshot.title} ${snapshot.url}`);
+}
+
+await mkdir(OUT_DIR, { recursive: true });
+
+const target = await getProfileV3Target();
+const cdp = new CdpClient(target.webSocketDebuggerUrl);
+await cdp.connect();
+await enableDomains(cdp);
+
+try {
+	const startUrl = await cdp.evaluate("location.href");
+	for (const [index, route] of routes.entries()) {
+		const label = route.startsWith("label:") ? route.slice("label:".length) : route;
+		if (route !== "current" && !route.startsWith("label:")) {
+			const nextUrl = route.startsWith("http")
+				? route
+				: new URL(route, startUrl).toString();
+			await cdp.send("Page.navigate", { url: nextUrl });
+		}
+		await scrapePage(cdp, label, index);
+	}
+}
+finally {
+	cdp.close();
+}


### PR DESCRIPTION
## Summary

This PR starts updating Improved Intra for the new Intra v3 profile experience. It adds V3-aware profile/banner detection, strengthens dark-mode coverage for the React/Tailwind shell, injects the Improved Intra settings entry into the V3 account menu, and includes a small CDP scraper for capturing V3 fixtures from a logged-in Chrome debugging session.

It also fixes a few console errors found while testing on current Intra pages, including the old account-menu `.closest()` crash on pages where the language link is missing, noisy runtime-port failures during back/forward-cache navigation, and unauthenticated sync-server responses resetting local options.

## Notes

This was a hobby-maintenance pass to keep the extension usable after the school changed the site. Most of the code in this PR was written with GPT-5.5 and then tested locally against a logged-in Chrome session.

## Validation

- `node --check background/comm.js`
- `node --check generic/useful.js`
- `node --check fixes/general.js`
- `node --check features/profiles.js`
- `node --check options/sync.js`
- `node --check options/unsync.js`
- `node --check options/auth2.js`
- `node --check scripts/cdp-scrape-intra-v3.mjs`
- Manual smoke test on `https://profile-v3.intra.42.fr/users/me` and `https://elearning.intra.42.fr/`
